### PR TITLE
Adds a LINK_DIRS variable to CMakeLists.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ install_package(
     DESTINATION ${CMAKE_INSTALL_PREFIX}/include
     INCLUDE_DIRS ${SDK_INCS}
     LINK_LIBS ${SDK_LIBS}
+    LINK_DIRS ${CMAKE_INSTALL_PREFIX}/lib
     )
 #########################################################################################
 # install doc


### PR DESCRIPTION
Fixes issue linking against this SDK library when installed locally using the `--install-prefix` flag. The root cause is that YDLIDAR_SDK_LIBRARY_DIRS is set to empty. LINK_DIRS (PACKAGE_LINK_DIRS) variable is used to set the YDLIDAR_SDK_LIBRARY_DIRS in the resulting ydlidar_sdkConfig.cmake file.

See discussion at https://github.com/colcon/colcon-core/issues/605 for details.