### PR TITLE
Correct typo in 'Intensity'

### DIFF
--- a/core/common/ydlidar_def.h
+++ b/core/common/ydlidar_def.h
@@ -66,7 +66,7 @@ typedef enum {
   LidarPropDeviceType,/**< lidar connection type code */
   LidarPropSampleRate,/**< lidar sample rate */
   LidarPropAbnormalCheckCount,/**< abnormal maximum check times */
-  LidarPropIntenstiyBit,/**< lidar intensity bit count */
+  LidarPropIntensityBit,/**< lidar intensity bit count */
   /* float properties */
   LidarPropMaxRange = 20,/**< lidar maximum range */
   LidarPropMinRange,/**< lidar minimum range */
@@ -79,7 +79,7 @@ typedef enum {
   LidarPropInverted,/**< lidar inverted flag */
   LidarPropAutoReconnect,/**< lidar hot plug flag */
   LidarPropSingleChannel,/**< lidar single-channel flag */
-  LidarPropIntenstiy,/**< lidar intensity flag */
+  LidarPropIntensity,/**< lidar intensity flag */
   LidarPropSupportMotorDtrCtrl,/**< lidar support motor Dtr ctrl flag */
   LidarPropSupportHeartBeat,/**< lidar support heartbeat flag */
 } LidarProperty;

--- a/doc/Dataset.md
+++ b/doc/Dataset.md
@@ -1,5 +1,5 @@
 # YDLIDAR DATASET
-|LIDAR      | Model  |  Baudrate |  SampleRate(K) | Range(m)  		   |  Frequency(HZ) | Intenstiy(bit) | SingleChannel | voltage(V)|
+|LIDAR      | Model  |  Baudrate |  SampleRate(K) | Range(m)  		   |  Frequency(HZ) | Intensity(bit) | SingleChannel | voltage(V)|
 | :-------- |:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | F4        | 1	   |  115200   |   4            |  0.12~12         | 5~12           | false          | false    	  | 4.8~5.2   |
 | S4        | 4	   |  115200   |   4            |  0.10~8.0        | 5~12 (PWM)     | false          | false    	  | 4.8~5.2   |

--- a/doc/YDLIDAR_SDK_API_for_Developers.md
+++ b/doc/YDLIDAR_SDK_API_for_Developers.md
@@ -24,7 +24,7 @@ This document provides an extensive technical deep dive into how to create, mani
 
 The first part of demonstrating YDLIDAR SDK API is to understand the ydlidar_test/tof_test/etlidar_Test example. Following are one optinal concepts:  `ydlidar::os_init()` (basic unit) of the example.
 
-### Create A System State 
+### Create A System State
 
 In the YDLIDAR SDK, the `ydlidar::os_init()` is optinal unit, If you need to accept `Ctrl + C` or other system abnormal signals. you can use it to create a system state, and check whether the system is normal by `ydlidar::os_isOk()`.
 The system signal creation interface is as follows:
@@ -98,7 +98,7 @@ int main(int argc, char *argv[]) {
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]) {
     fflush(stderr);
   }
 
-  // Turn On success and loop  
+  // Turn On success and loop
   while (ret && ydlidar::os_isOk()) {
     LaserScan scan;
     if (laser.doProcessSimple(scan)) {
@@ -210,7 +210,7 @@ int main(int argc, char *argv[]) {
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -240,7 +240,7 @@ int main(int argc, char *argv[]) {
     fflush(stderr);
   }
 
-  // Turn On success and loop  
+  // Turn On success and loop
   while (ret && ydlidar::os_isOk()) {
     LaserScan scan;
     if (laser.doProcessSimple(scan)) {
@@ -338,7 +338,7 @@ There are two ways to integrate YDLIDAR SDK into your project.
 * [Add source code to the Project](#add-source-code-to-the-project).
     - [Copy YDLIDAR SDK to your project](#copy-ydlidar-sdk-to-your-project)
     - [Add YDLIDAR SDK project to the CMakeLists file of your project](#add-ydlidar-sdk-project-to-the-cmakelists-file-of-your-project)
-  
+
 
 ### Calling a compliled library
 The implementation of the demo mainly includes the following steps.
@@ -410,7 +410,7 @@ target_link_libraries(${PROJECT_NAME} ydlidar_sdk)
 
 ############## YDLIDAR SDK END#####################################
 ```
-Note: 
+Note:
 * If you do not want to generate samples in YDLidar-SDK, Add the following options when compiling:
 ```shell
 $cmake -DBUILD_EXAMPLES=OFF ../ && make
@@ -472,7 +472,7 @@ For additional information and examples, refer to [CYDLidar](#cydlidar)
 * - @ref LidarPropInverted
 * - @ref LidarPropAutoReconnect
 * - @ref LidarPropSingleChannel
-* - @ref LidarPropIntenstiy
+* - @ref LidarPropIntensity
 * - @ref LidarPropSupportMotorDtrCtrl
 * - @ref LidarPropSupportHeartBeat
 * @note set bool property example
@@ -534,7 +534,7 @@ bool setlidaropt(int optname, const void *optval, int optlen);
 * - @ref LidarPropInverted
 * - @ref LidarPropAutoReconnect
 * - @ref LidarPropSingleChannel
-* - @ref LidarPropIntenstiy
+* - @ref LidarPropIntensity
 * - @ref LidarPropSupportMotorDtrCtrl
 * - @ref LidarPropSupportHeartBeat
 * @note get bool property example
@@ -652,7 +652,7 @@ void lidarDestroy(YDLidar **lidar);
  * - @ref LidarPropInverted
  * - @ref LidarPropAutoReconnect
  * - @ref LidarPropSingleChannel
- * - @ref LidarPropIntenstiy
+ * - @ref LidarPropIntensity
  * - @ref LidarPropSupportMotorDtrCtrl
  * - @ref LidarPropSupportHeartBeat
  * @note set bool property example
@@ -715,7 +715,7 @@ bool setlidaropt(YDLidar *lidar, int optname, const void *optval, int optlen);
  * - @ref LidarPropInverted
  * - @ref LidarPropAutoReconnect
  * - @ref LidarPropSingleChannel
- * - @ref LidarPropIntenstiy
+ * - @ref LidarPropIntensity
  * - @ref LidarPropSupportMotorDtrCtrl
  * - @ref LidarPropSupportHeartBeat
  * @note get bool property example
@@ -1340,7 +1340,7 @@ The Table that the user uses to perform parameter related operations:
 For additional information and examples, refer to [Parameter](#code-example)
 
 ### Table List - Models
-|LIDAR      | Model  |  Baudrate |  SampleRate(K) | Range(m)  		   |  Frequency(HZ) | Intenstiy(bit) | SingleChannel | voltage(V)|
+|LIDAR      | Model  |  Baudrate |  SampleRate(K) | Range(m)  		   |  Frequency(HZ) | Intensity(bit) | SingleChannel | voltage(V)|
 | :-------- |:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | F4        | 1	   |  115200   |   4            |  0.12~12         | 5~12           | false          | false    	  | 4.8~5.2   |
 | S4        | 4	   |  115200   |   4            |  0.10~8.0        | 5~12 (PWM)     | false          | false    	  | 4.8~5.2   |

--- a/doc/tutorials/writing_lidar_network_adapter_tutorial_c++.md
+++ b/doc/tutorials/writing_lidar_network_adapter_tutorial_c++.md
@@ -19,7 +19,7 @@ Tutorial Level: BEGINNER
 mkdir beginner_tutorials
 cd beginner_tutorials
 ```
-### Create the lidar_tutorial.cpp file within the beginner_tutorials project and paste the following inside it: 
+### Create the lidar_tutorial.cpp file within the beginner_tutorials project and paste the following inside it:
 [https://github.com/YDLIDAR/ydlidar_tutorials/blob/master/cpp_tutorials/lidar_tutorial/lidar_tutorial.cpp](https://github.com/YDLIDAR/ydlidar_tutorials/blob/master/cpp_tutorials/lidar_tutorial/lidar_tutorial.cpp)
 
 ```c++
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -110,7 +110,7 @@ int main(int argc, char *argv[]) {
     fflush(stderr);
   }
 
-  // Turn On success and loop  
+  // Turn On success and loop
   while (ret && ydlidar::os_isOk()) {
     LaserScan scan;
     if (laser.doProcessSimple(scan)) {
@@ -140,11 +140,11 @@ The device type `LidarPropDeviceType` value is changed from the `YDLIDAR_TYPE_SE
 
 
 ### The Code Explained
-Now, let's break the code down. 
+Now, let's break the code down.
 ```c++
 #include "CYdLidar.h"
 ```
-CYdLidar.h is a convenience include that includes all the headers necessary to use the most common public pieces of the YDLIDAR SDK. 
+CYdLidar.h is a convenience include that includes all the headers necessary to use the most common public pieces of the YDLIDAR SDK.
 
 ```c++
   ydlidar::os_init();
@@ -154,7 +154,7 @@ Initialize system signal. install a SIGINT handler which provides Ctrl-C handlin
 ```c++
   CYdLidar laser;
 ```
-Create a handle to this Lidar. 
+Create a handle to this Lidar.
 
 ```c++
  //////////////////////string property/////////////////
@@ -213,7 +213,7 @@ Set Lidar string int paramters.
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -269,7 +269,7 @@ Start the device scanning routine which runs on a separate thread and enable mot
 
 
 ```c++
-  // Turn On success and loop  
+  // Turn On success and loop
   while (ret && ydlidar::os_isOk()) {
 ```
 By `ydlidar::os_init()` will install a SIGINT handler which provides Ctrl-C handling which will cause `ydlidar::os_isOk()` to return false if that happens.
@@ -349,17 +349,17 @@ Linux:
    you need to put `YDLIDAR_SDK_LIBRARIES` at the end.
 
 
-you can use the following variable to depend on all necessary targets: 
+you can use the following variable to depend on all necessary targets:
 
 ```cmake
 target_link_libraries(${PROJECT_NAME} ${YDLIDAR_SDK_LIBRARIES})
 ```
-Now run cmake: 
+Now run cmake:
 ```cmake
 # In your project directory
 mkdir build
 cd build
 cmake ..
-make j4  
+make j4
 ```
-Now that you have written a simple lidar tutorial, let's [examine the simple lidar tutorial](examine_the_simple_lidar_tutorial.md). 
+Now that you have written a simple lidar tutorial, let's [examine the simple lidar tutorial](examine_the_simple_lidar_tutorial.md).

--- a/doc/tutorials/writing_lidar_tutorial_c++.md
+++ b/doc/tutorials/writing_lidar_tutorial_c++.md
@@ -19,7 +19,7 @@ Tutorial Level: BEGINNER
 mkdir beginner_tutorials
 cd beginner_tutorials
 ```
-### Create the lidar_tutorial.cpp file within the beginner_tutorials project and paste the following inside it: 
+### Create the lidar_tutorial.cpp file within the beginner_tutorials project and paste the following inside it:
 [https://github.com/YDLIDAR/ydlidar_tutorials/blob/master/cpp_tutorials/lidar_tutorial/lidar_tutorial.cpp](https://github.com/YDLIDAR/ydlidar_tutorials/blob/master/cpp_tutorials/lidar_tutorial/lidar_tutorial.cpp)
 
 ```c++
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -118,7 +118,7 @@ int main(int argc, char *argv[]) {
     fflush(stderr);
   }
 
-  // Turn On success and loop  
+  // Turn On success and loop
   while (ret && ydlidar::os_isOk()) {
     LaserScan scan;
     if (laser.doProcessSimple(scan)) {
@@ -140,11 +140,11 @@ int main(int argc, char *argv[]) {
 ```
 
 ### The Code Explained
-Now, let's break the code down. 
+Now, let's break the code down.
 ```c++
 #include "CYdLidar.h"
 ```
-CYdLidar.h is a convenience include that includes all the headers necessary to use the most common public pieces of the YDLIDAR SDK. 
+CYdLidar.h is a convenience include that includes all the headers necessary to use the most common public pieces of the YDLIDAR SDK.
 
 ```c++
   ydlidar::os_init();
@@ -154,7 +154,7 @@ Initialize system signal. install a SIGINT handler which provides Ctrl-C handlin
 ```c++
   CYdLidar laser;
 ```
-Create a handle to this Lidar. 
+Create a handle to this Lidar.
 
 ```c++
  //////////////////////string property/////////////////
@@ -217,7 +217,7 @@ Set Lidar string int paramters.
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -273,7 +273,7 @@ Start the device scanning routine which runs on a separate thread and enable mot
 
 
 ```c++
-  // Turn On success and loop  
+  // Turn On success and loop
   while (ret && ydlidar::os_isOk()) {
 ```
 By `ydlidar::os_init()` will install a SIGINT handler which provides Ctrl-C handling which will cause `ydlidar::os_isOk()` to return false if that happens.
@@ -353,17 +353,17 @@ Linux:
    you need to put `YDLIDAR_SDK_LIBRARIES` at the end.
 
 
-you can use the following variable to depend on all necessary targets: 
+you can use the following variable to depend on all necessary targets:
 
 ```cmake
 target_link_libraries(${PROJECT_NAME} ${YDLIDAR_SDK_LIBRARIES})
 ```
-Now run cmake: 
+Now run cmake:
 ```cmake
 # In your project directory
 mkdir build
 cd build
 cmake ..
-make j4  
+make j4
 ```
-Now that you have written a simple lidar tutorial, let's [examine the simple lidar tutorial](examine_the_simple_lidar_tutorial.md). 
+Now that you have written a simple lidar tutorial, let's [examine the simple lidar tutorial](examine_the_simple_lidar_tutorial.md).

--- a/doc/tutorials/writing_lidar_tutorial_c.md
+++ b/doc/tutorials/writing_lidar_tutorial_c.md
@@ -19,7 +19,7 @@ Tutorial Level: BEGINNER
 mkdir beginner_tutorials
 cd beginner_tutorials
 ```
-### Create the lidar_tutorial.cpp file within the beginner_tutorials project and paste the following inside it: 
+### Create the lidar_tutorial.cpp file within the beginner_tutorials project and paste the following inside it:
 [https://github.com/YDLIDAR/ydlidar_tutorials/blob/master/c_tutorials/lidar_tutorial/lidar_tutorial.c](https://github.com/YDLIDAR/ydlidar_tutorials/blob/master/c_tutorials/lidar_tutorial/lidar_tutorial.c)
 
 ```c
@@ -94,7 +94,7 @@ int main(int argc, const char *argv[]) {
     setlidaropt(laser, LidarPropAutoReconnect, &b_optval, sizeof(bool));
     b_optval = false;
     setlidaropt(laser, LidarPropSingleChannel, &b_optval, sizeof(bool));
-    setlidaropt(laser, LidarPropIntenstiy, &b_optval, sizeof(bool));
+    setlidaropt(laser, LidarPropIntensity, &b_optval, sizeof(bool));
     setlidaropt(laser, LidarPropInverted, &b_optval, sizeof(bool));
     setlidaropt(laser, LidarPropReversion, &b_optval, sizeof(bool));
     setlidaropt(laser, LidarPropSupportMotorDtrCtrl, &b_optval, sizeof(bool));
@@ -143,11 +143,11 @@ int main(int argc, const char *argv[]) {
 ```
 
 ### The Code Explained
-Now, let's break the code down. 
+Now, let's break the code down.
 ```c++
 #include "ydlidar_sdk.h"
 ```
-ydlidar_sdk.h is a convenience include that includes all the headers necessary to use the most common public pieces of the YDLIDAR SDK. 
+ydlidar_sdk.h is a convenience include that includes all the headers necessary to use the most common public pieces of the YDLIDAR SDK.
 
 ```c
   os_init();
@@ -157,7 +157,7 @@ Initialize system signal. install a SIGINT handler which provides Ctrl-C handlin
 ```c
   YDLidar *laser = lidarCreate();
 ```
-Create a handle to this Lidar. 
+Create a handle to this Lidar.
 
 ```c
   //string prop
@@ -201,7 +201,7 @@ Set Lidar string int paramters.
   setlidaropt(laser, LidarPropAutoReconnect, &b_optval, sizeof(bool));
   b_optval = false;
   setlidaropt(laser, LidarPropSingleChannel, &b_optval, sizeof(bool));
-  setlidaropt(laser, LidarPropIntenstiy, &b_optval, sizeof(bool));
+  setlidaropt(laser, LidarPropIntensity, &b_optval, sizeof(bool));
   setlidaropt(laser, LidarPropInverted, &b_optval, sizeof(bool));
   setlidaropt(laser, LidarPropReversion, &b_optval, sizeof(bool));
   setlidaropt(laser, LidarPropSupportMotorDtrCtrl, &b_optval, sizeof(bool));
@@ -250,7 +250,7 @@ Start the device scanning routine which runs on a separate thread and enable mot
 
 
 ```c
-  // Turn On success and loop  
+  // Turn On success and loop
   LaserFan scan;
   LaserFanInit(&scan);
   while (ret && os_isOk()) {
@@ -262,7 +262,7 @@ By `os_init()` will install a SIGINT handler which provides Ctrl-C handling whic
 + ydlidar::os_shutdown() has been called by another part of the application.
 
 Once `os_isOk()` returns false, Loop exit.
-Note: 
+Note:
 + `LaserFan` need to be initialized with `LaserFanInit`
 - After `LaserFan` leaves the Scope, it need to be destroyed with `LaserFanDestroy`, otherwisw it will leak memory.
 
@@ -342,17 +342,17 @@ ydlidar_sdk dependent libraries
 Note:
 * GCC CCLDFLAGS requires "-lstdc++ -lm".
 
-you can use the following variable to depend on all necessary targets: 
+you can use the following variable to depend on all necessary targets:
 
 ```cmake
 target_link_libraries(${PROJECT_NAME} ${YDLIDAR_SDK_LIBRARIES} -lstdc++ -lm)
 ```
-Now run cmake: 
+Now run cmake:
 ```cmake
 # In your project directory
 mkdir build
 cd build
 cmake ..
-make j4  
+make j4
 ```
-Now that you have written a simple lidar tutorial, let's [examine the simple lidar tutorial](examine_the_simple_lidar_tutorial.md). 
+Now that you have written a simple lidar tutorial, let's [examine the simple lidar tutorial](examine_the_simple_lidar_tutorial.md).

--- a/examples/et_test.cpp
+++ b/examples/et_test.cpp
@@ -141,7 +141,7 @@ int main(int argc, char *argv[]) {
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));

--- a/examples/gs_ota.cpp
+++ b/examples/gs_ota.cpp
@@ -184,9 +184,9 @@ int main(int argc, char *argv[])
   /// abnormal count
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 8;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = true;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));

--- a/examples/gs_test.cpp
+++ b/examples/gs_test.cpp
@@ -63,7 +63,7 @@ using namespace ydlidar;
  * Step7: Uninitialize the SDK and Disconnect the LiDAR.(::CYdLidar::disconnecting)\n
  */
 
-int main(int argc, char *argv[]) 
+int main(int argc, char *argv[])
 {
   printf("__   ______  _     ___ ____    _    ____  \n");
   printf("\\ \\ / /  _ \\| |   |_ _|  _ \\  / \\  |  _ \\ \n");
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
     printf("[%d] %d\n", it->first, it->second);
   }
 
-  while (ydlidar::os_isOk()) 
+  while (ydlidar::os_isOk())
   {
     printf("Please select the lidar baudrate:");
     std::string number;
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
   int optval = TYPE_GS;
   laser.setlidaropt(LidarPropLidarType, &optval, sizeof(int));
   /// device type (YDLIDAR_TYPE_TCP,YDLIDAR_TYPE_SERIAL)
-  optval = baudrate == baudrateList[0] ? YDLIDAR_TYPE_TCP : YDLIDAR_TYPE_SERIAL; 
+  optval = baudrate == baudrateList[0] ? YDLIDAR_TYPE_TCP : YDLIDAR_TYPE_SERIAL;
   laser.setlidaropt(LidarPropDeviceType, &optval, sizeof(int));
   /// sample rate
   optval = isSingleChannel ? 3 : 4;
@@ -172,9 +172,9 @@ int main(int argc, char *argv[])
   /// abnormal count
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 8;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = true;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -213,7 +213,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropScanFrequency, &frequency, sizeof(float));
 
   //是否启用调试
-  laser.setEnableDebug(false); 
+  laser.setEnableDebug(false);
 
   //雷达初始化
   bool ret = laser.initialize();
@@ -273,12 +273,12 @@ int main(int argc, char *argv[])
         scan.moduleNum,
         int(scan.points.size()),
         scan.scanFreq);
-      
+
       //打印帧间隔
       // uint32_t t = getms();
       // printf("module[%d] time[%lld]\n", scan.moduleNum, t - ts[scan.moduleNum]);
       // ts[scan.moduleNum] = t;
-      
+
       //打印点云
       // for (size_t i = 0; i < scan.points.size(); ++i)
       // {

--- a/examples/gs_test2.cpp
+++ b/examples/gs_test2.cpp
@@ -98,7 +98,7 @@ struct Yd3DPoints
 bool parseCsv(const std::string& name, YdGsOutParam& op);
 bool to3D(const LaserScan& scan, const YdGsOutParam& op, Yd3DPoints& out);
 
-int main(int argc, char *argv[]) 
+int main(int argc, char *argv[])
 {
   printf("__   ______  _     ___ ____    _    ____  \n");
   printf("\\ \\ / /  _ \\| |   |_ _|  _ \\  / \\  |  _ \\ \n");
@@ -159,7 +159,7 @@ int main(int argc, char *argv[])
        it != baudrateList.end(); it++) {
     printf("[%d] %d\n", it->first, it->second);
   }
-  while (ydlidar::os_isOk()) 
+  while (ydlidar::os_isOk())
   {
     printf("Please select the lidar baudrate:");
     std::string number;
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
   int optval = TYPE_GS;
   laser.setlidaropt(LidarPropLidarType, &optval, sizeof(int));
   /// device type (YDLIDAR_TYPE_TCP,YDLIDAR_TYPE_SERIAL)
-  optval = (baudrate == baudrateList[0]) ? YDLIDAR_TYPE_TCP : YDLIDAR_TYPE_SERIAL; 
+  optval = (baudrate == baudrateList[0]) ? YDLIDAR_TYPE_TCP : YDLIDAR_TYPE_SERIAL;
   laser.setlidaropt(LidarPropDeviceType, &optval, sizeof(int));
   /// sample rate
   optval = isSingleChannel ? 3 : 4;
@@ -199,9 +199,9 @@ int main(int argc, char *argv[])
   /// abnormal count
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 8;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
   //////////////////////bool property/////////////////
   /// fixed angle resolution
   bool b_optvalue = false;
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = true;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropScanFrequency, &frequency, sizeof(float));
 
   //是否启用调试
-  laser.setEnableDebug(false); 
+  laser.setEnableDebug(false);
 
   //雷达初始化
   bool ret = laser.initialize();
@@ -341,12 +341,12 @@ bool parseCsv(const std::string& name, YdGsOutParam& op)
   std::string line;
   std::string format = "%f %f %f %f";
   int index = 0;
-  while (getline(file, line)) 
-  { 
+  while (getline(file, line))
+  {
     if (line.empty())
       continue;
-    if (std::sscanf(line.c_str(), format.c_str(), 
-      &op.items[index].b0, 
+    if (std::sscanf(line.c_str(), format.c_str(),
+      &op.items[index].b0,
       &op.items[index].b1,
       &op.items[index].k0,
       &op.items[index].k1) == 4) //解析成功

--- a/examples/lidar_c_api_test.c
+++ b/examples/lidar_c_api_test.c
@@ -69,7 +69,7 @@ int main(int argc, const char *argv[]) {
     setlidaropt(laser, LidarPropAutoReconnect, &b_optval, sizeof(bool));
     b_optval = false;
     setlidaropt(laser, LidarPropSingleChannel, &b_optval, sizeof(bool));
-    setlidaropt(laser, LidarPropIntenstiy, &b_optval, sizeof(bool));
+    setlidaropt(laser, LidarPropIntensity, &b_optval, sizeof(bool));
     setlidaropt(laser, LidarPropInverted, &b_optval, sizeof(bool));
     setlidaropt(laser, LidarPropReversion, &b_optval, sizeof(bool));
     setlidaropt(laser, LidarPropSupportMotorDtrCtrl, &b_optval, sizeof(bool));

--- a/examples/scl_test.cpp
+++ b/examples/scl_test.cpp
@@ -233,9 +233,9 @@ int main(int argc, char *argv[])
   /// abnormal count
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 10;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -251,7 +251,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));

--- a/examples/sdm18_test.cpp
+++ b/examples/sdm18_test.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
   //   int id = 0;
   //   for (it = ports.begin(); it != ports.end(); it++)
   //   {
-  //     printf("[%d] %s %s\n", 
+  //     printf("[%d] %s %s\n",
   //       id, it->first.c_str(), it->second.c_str());
   //     id++;
   //   }
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
   int baudrate = 921600; //默认串口号
 
   bool isSingleChannel = false;
-  
+
   CYdLidar laser;
   //////////////////////string property/////////////////
   /// lidar port
@@ -149,9 +149,9 @@ int main(int argc, char *argv[])
   /// abnormal count
   optval = 3;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 8;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = true;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));

--- a/examples/sdm_test.cpp
+++ b/examples/sdm_test.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     int id = 0;
     for (it = ports.begin(); it != ports.end(); it++)
     {
-      printf("[%d] %s %s\n", 
+      printf("[%d] %s %s\n",
         id, it->first.c_str(), it->second.c_str());
       id++;
     }
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
   int baudrate = 460800; //默认串口号
 
   bool isSingleChannel = false;
-  
+
   CYdLidar laser;
   //////////////////////string property/////////////////
   /// lidar port
@@ -149,9 +149,9 @@ int main(int argc, char *argv[])
   /// abnormal count
   optval = 3;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 4;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = true;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -214,7 +214,7 @@ int main(int argc, char *argv[])
       for (size_t i = 0; i < scan.points.size(); ++i)
       {
         const LaserPoint &p = scan.points.at(i);
-        printf("%lu R %.01f I %.01f\n", i, 
+        printf("%lu R %.01f I %.01f\n", i,
           p.range * 1000.0f, p.intensity);
       }
       fflush(stdout);

--- a/examples/tea_test.cpp
+++ b/examples/tea_test.cpp
@@ -201,7 +201,7 @@ int main(int argc, char *argv[])
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
   //  optval = 16;
-  //  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  //  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
 
@@ -276,7 +276,7 @@ int main(int argc, char *argv[])
       //     scan.config.scan_time,
       //     scan.config.time_increment);
       // }
-      
+
       // core::common::info("[%u] points Stamp [%u]ms",
       //   uint32_t(scan.points.size()),
       //   uint32_t(scan.stamp / 1000000));

--- a/examples/tmini_test.cpp
+++ b/examples/tmini_test.cpp
@@ -205,9 +205,9 @@ int main(int argc, char *argv[]) {
   /// abnormal count
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 8;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -224,7 +224,7 @@ int main(int argc, char *argv[]) {
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = true;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = false;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -276,7 +276,7 @@ int main(int argc, char *argv[]) {
         for (size_t i = 0; i < scan.points.size(); ++i)
         {
           const LaserPoint &p = scan.points.at(i);
-          printf("%d a %.01f r %.04f i %.0f\n", 
+          printf("%d a %.01f r %.04f i %.0f\n",
             i, p.angle * 180.0 / M_PI, p.range, p.intensity);
         }
         fflush(stdout);

--- a/examples/tof_test.cpp
+++ b/examples/tof_test.cpp
@@ -209,7 +209,7 @@ int main(int argc, char *argv[]) {
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
 //  optval = 16;
-//  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+//  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -226,7 +226,7 @@ int main(int argc, char *argv[]) {
   laser.setlidaropt(LidarPropSingleChannel, &b_optvalue, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
 

--- a/examples/tri_and_gs_test.cpp
+++ b/examples/tri_and_gs_test.cpp
@@ -48,9 +48,9 @@ int main(int argc, char *argv[])
     /// abnormal count
     optval = 4;
     lidarGs.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-    /// Intenstiy bit count
+    /// Intensity bit count
     optval = 8;
-    lidarGs.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+    lidarGs.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
     //////////////////////bool property/////////////////
     /// fixed angle resolution
     bool b_optvalue = false;
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
     lidarGs.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
     /// intensity
     b_optvalue = true;
-    lidarGs.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+    lidarGs.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
     /// Motor DTR
     b_optvalue = true;
     lidarGs.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));
@@ -120,9 +120,9 @@ int main(int argc, char *argv[])
     /// abnormal count
     optval = 4;
     lidarS2.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-    /// Intenstiy bit count
+    /// Intensity bit count
     optval = 10;
-    lidarS2.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+    lidarS2.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
     //////////////////////bool property/////////////////
     /// fixed angle resolution
     bool b_optvalue = true;
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
     lidarS2.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
     /// intensity
     b_optvalue = true;
-    lidarS2.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+    lidarS2.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
     /// Motor DTR
     b_optvalue = false;
     lidarS2.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));

--- a/examples/tri_restart.cpp
+++ b/examples/tri_restart.cpp
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
   ydlidar::os_init();
 
   bool ret = false;
- 
+
   CYdLidar lidarS2; //S2雷达
   {
     bool isSingleChannel = false;
@@ -50,9 +50,9 @@ int main(int argc, char *argv[])
     /// abnormal count
     optval = 4;
     lidarS2.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-    /// Intenstiy bit count
+    /// Intensity bit count
     optval = 10;
-    lidarS2.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+    lidarS2.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
     //////////////////////bool property/////////////////
     /// fixed angle resolution
     bool b_optvalue = false;
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     lidarS2.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
     /// intensity
     b_optvalue = true;
-    lidarS2.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+    lidarS2.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
     /// Motor DTR
     b_optvalue = false;
     lidarS2.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));

--- a/examples/tri_test.cpp
+++ b/examples/tri_test.cpp
@@ -222,9 +222,9 @@ int main(int argc, char *argv[])
   /// abnormal count
   optval = 4;
   laser.setlidaropt(LidarPropAbnormalCheckCount, &optval, sizeof(int));
-  /// Intenstiy bit count
+  /// Intensity bit count
   optval = 10;
-  laser.setlidaropt(LidarPropIntenstiyBit, &optval, sizeof(int));
+  laser.setlidaropt(LidarPropIntensityBit, &optval, sizeof(int));
 
   //////////////////////bool property/////////////////
   /// fixed angle resolution
@@ -243,7 +243,7 @@ int main(int argc, char *argv[])
   laser.setlidaropt(LidarPropSingleChannel, &isSingleChannel, sizeof(bool));
   /// intensity
   b_optvalue = false;
-  laser.setlidaropt(LidarPropIntenstiy, &b_optvalue, sizeof(bool));
+  laser.setlidaropt(LidarPropIntensity, &b_optvalue, sizeof(bool));
   /// Motor DTR
   b_optvalue = true;
   laser.setlidaropt(LidarPropSupportMotorDtrCtrl, &b_optvalue, sizeof(bool));

--- a/python/examples/etlidar_test.py
+++ b/python/examples/etlidar_test.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
     laser.setlidaropt(ydlidar.LidarPropScanFrequency, 20.0);
     laser.setlidaropt(ydlidar.LidarPropSampleRate, 20);
     laser.setlidaropt(ydlidar.LidarPropSingleChannel, False);
-    laser.setlidaropt(ydlidar.LidarPropIntenstiy, True);
+    laser.setlidaropt(ydlidar.LidarPropIntensity, True);
 
     ret = laser.initialize();
     if ret:

--- a/python/examples/gs_test.py
+++ b/python/examples/gs_test.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     laser.setlidaropt(ydlidar.LidarPropScanFrequency, 30.0);
     laser.setlidaropt(ydlidar.LidarPropSampleRate, 20);
     laser.setlidaropt(ydlidar.LidarPropSingleChannel, False);
-    laser.setlidaropt(ydlidar.LidarPropIntenstiy, True);
+    laser.setlidaropt(ydlidar.LidarPropIntensity, True);
     laser.setlidaropt(ydlidar.LidarPropMaxAngle, 180.0);
     laser.setlidaropt(ydlidar.LidarPropMinAngle, -180.0);
     laser.setlidaropt(ydlidar.LidarPropMaxRange, 50.0);

--- a/python/examples/tea_test.py
+++ b/python/examples/tea_test.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     laser.setlidaropt(ydlidar.LidarPropScanFrequency, 20.0);
     laser.setlidaropt(ydlidar.LidarPropSampleRate, 20);
     laser.setlidaropt(ydlidar.LidarPropSingleChannel, False);
-    laser.setlidaropt(ydlidar.LidarPropIntenstiy, True);
+    laser.setlidaropt(ydlidar.LidarPropIntensity, True);
     laser.setlidaropt(ydlidar.LidarPropMaxAngle, 180.0);
     laser.setlidaropt(ydlidar.LidarPropMinAngle, -180.0);
     laser.setlidaropt(ydlidar.LidarPropMaxRange, 50.0);

--- a/python/examples/tri_test.py
+++ b/python/examples/tri_test.py
@@ -21,7 +21,7 @@ if __name__ == "__main__":
     laser.setlidaropt(ydlidar.LidarPropMinAngle, -180.0);
     laser.setlidaropt(ydlidar.LidarPropMaxRange, 16.0);
     laser.setlidaropt(ydlidar.LidarPropMinRange, 0.08);
-    laser.setlidaropt(ydlidar.LidarPropIntenstiy, False);
+    laser.setlidaropt(ydlidar.LidarPropIntensity, False);
 
     ret = laser.initialize();
     if ret:

--- a/python/test/pytest.py
+++ b/python/test/pytest.py
@@ -1,4 +1,6 @@
 import unittest
+
+
 import ydlidar
 
 
@@ -30,8 +32,8 @@ class PyTestTestCase(unittest.TestCase):
     self.assertTrue(ret);
     self.assertEqual(maxRange, mRange);
     intensity = False;
-    laser.setlidaropt(ydlidar.LidarPropIntenstiy, intensity);
-    ret, quality = laser.getlidaropt_toBool(ydlidar.LidarPropIntenstiy);
+    laser.setlidaropt(ydlidar.LidarPropIntensity, intensity);
+    ret, quality = laser.getlidaropt_toBool(ydlidar.LidarPropIntensity);
     self.assertTrue(ret);
     self.assertEqual(intensity, quality);
 

--- a/src/CYdLidar.cpp
+++ b/src/CYdLidar.cpp
@@ -196,10 +196,10 @@ bool CYdLidar::setlidaropt(int optname, const void *optval, int optlen)
     m_SingleChannel = *(bool *)(optval);
     break;
 
-  case LidarPropIntenstiy:
+  case LidarPropIntensity:
     m_Intensity = *(bool *)(optval);
     break;
-  case LidarPropIntenstiyBit:
+  case LidarPropIntensityBit:
     m_IntensityBit = *(int *)(optval);
     break;
 
@@ -346,10 +346,10 @@ bool CYdLidar::getlidaropt(int optname, void *optval, int optlen)
     memcpy(optval, &m_SingleChannel, optlen);
     break;
 
-  case LidarPropIntenstiy:
+  case LidarPropIntensity:
     memcpy(optval, &m_Intensity, optlen);
     break;
-  case LidarPropIntenstiyBit:
+  case LidarPropIntensityBit:
     memcpy(optval, &m_IntensityBit, optlen);
     break;
 
@@ -632,7 +632,7 @@ bool CYdLidar::doProcessSimple(LaserScan &outscan)
     outscan.config.min_angle = math::from_degrees(m_MinAngle);
     outscan.config.max_angle = math::from_degrees(m_MaxAngle);
     //将首末点采集时间差作为采集时长
-    // outscan.config.scan_time = static_cast<float>((global_nodes[count - 1].stamp - 
+    // outscan.config.scan_time = static_cast<float>((global_nodes[count - 1].stamp -
     //   global_nodes[0].stamp)) / 1e9;
     // outscan.config.scan_time = sys_scan_time / 1e9;
     if (lastStamp > 0 && global_nodes[0].stamp > 0)
@@ -679,7 +679,7 @@ bool CYdLidar::doProcessSimple(LaserScan &outscan)
     {
       const node_info& node = global_nodes[i];
 
-      // printf("%lu a %.01f r %u\n", 
+      // printf("%lu a %.01f r %u\n",
       //   i, float(node.angle) / 64.0f, node.dist);
 
       if (isNetTOFLidar(m_LidarType))
@@ -702,7 +702,7 @@ bool CYdLidar::doProcessSimple(LaserScan &outscan)
       }
       else
       {
-        if (isTOFLidar(m_LidarType) || 
+        if (isTOFLidar(m_LidarType) ||
           isNetTOFLidar(m_LidarType) ||
           isGSLidar(m_LidarType) ||
           isSDMLidar(m_LidarType) ||
@@ -734,7 +734,7 @@ bool CYdLidar::doProcessSimple(LaserScan &outscan)
         else if (isTEALidar(lidar_model) ||
           isGSLidar(m_LidarType)) //TEA雷达转速范围10~30，无缩放
         {
-          scanfrequency = global_nodes[i].scanFreq; 
+          scanfrequency = global_nodes[i].scanFreq;
         }
       }
 
@@ -1037,7 +1037,7 @@ bool CYdLidar::getDeviceInfoByPackage(const LaserDebug &debug)
                     resample
 -------------------------------------------------------------*/
 void CYdLidar::resample(
-  int frequency, int count, 
+  int frequency, int count,
   uint64_t tim_scan_end,
   uint64_t tim_scan_start)
 {
@@ -1088,12 +1088,12 @@ bool CYdLidar::checkLidarAbnormal()
 
   result_t ret = RESULT_FAIL;
   std::vector<int> data;
-  
+
   while (checkCount < m_AbnormalCheckCount)
   {
     // printf("checkLidarAbnormal %d\n", checkCount);
 
-    // Ensure that the voltage is insufficient or the motor resistance is high, 
+    // Ensure that the voltage is insufficient or the motor resistance is high,
     //causing an abnormality.
     if (checkCount)
       delay(500);
@@ -1115,7 +1115,7 @@ bool CYdLidar::checkLidarAbnormal()
       ret = lidarPtr->grabScanData(global_nodes, count);
       end_time = getTime();
       scan_time = 1.0 * static_cast<int64_t>(end_time - start_time) / 1e9;
-      
+
       if (IS_OK(ret))
       {
         // 获取CT信息
@@ -1304,7 +1304,7 @@ bool CYdLidar::calcSampleRate(int count, double scan_time)
     lidarPtr->setPointTime(m_PointTime);
     if (!m_SingleChannel)
       m_FixedSize = m_SampleRate * 1000 / (m_ScanFrequency - 0.1);
-    
+
     if (!isSDMLidar(m_LidarType)) //非SDM雷达才打印Fixed Size
       printf("[YDLIDAR] Fixed Size: %d\n", m_FixedSize);
     printf("[YDLIDAR] Sample Rate: %.02fK\n", m_SampleRate);
@@ -1461,8 +1461,8 @@ bool CYdLidar::getDeviceInfo()
 
   // printf("LIDAR get device info finished, Elapsed time %u ms\n", getms() - t);
   //检查转速
-  if (hasScanFrequencyCtrl(di.model) || 
-    ((isTOFLidar(m_LidarType)) && !m_SingleChannel) || 
+  if (hasScanFrequencyCtrl(di.model) ||
+    ((isTOFLidar(m_LidarType)) && !m_SingleChannel) ||
       isNetTOFLidar(m_LidarType))
   {
     checkScanFrequency();
@@ -1733,7 +1733,7 @@ bool CYdLidar::checkCalibrationAngle(const std::string &serialNumber)
 bool CYdLidar::checkCOMMs()
 {
   //如果雷达类型有变化则需要先删除旧对象
-  if (lidarPtr && 
+  if (lidarPtr &&
     lidarPtr->getLidarType() != m_LidarType)
   {
     delete lidarPtr;
@@ -1816,7 +1816,7 @@ bool CYdLidar::checkCOMMs()
   lidarPtr->setOtaName(otaName);
   lidarPtr->setOtaEncode(otaEncode);
 
-  printf("[YDLIDAR] Lidar successfully connected [%s:%d]\n", 
+  printf("[YDLIDAR] Lidar successfully connected [%s:%d]\n",
     m_SerialPort.c_str(), m_SerialBaudrate);
   return true;
 }

--- a/src/ydlidar_sdk.h
+++ b/src/ydlidar_sdk.h
@@ -95,7 +95,7 @@ YDLIDAR_API void lidarDestroy(YDLidar **lidar);
  * - @ref LidarPropInverted
  * - @ref LidarPropAutoReconnect
  * - @ref LidarPropSingleChannel
- * - @ref LidarPropIntenstiy
+ * - @ref LidarPropIntensity
  * @note set bool property example
  * @code
  * CYdLidar laser;
@@ -157,7 +157,7 @@ YDLIDAR_API bool setlidaropt(YDLidar *lidar, int optname, const void *optval,
  * - @ref LidarPropInverted
  * - @ref LidarPropAutoReconnect
  * - @ref LidarPropSingleChannel
- * - @ref LidarPropIntenstiy
+ * - @ref LidarPropIntensity
  * @note get bool property example
  * @code
  * CYdLidar laser;


### PR DESCRIPTION
The property `LidarPropIntensity` was spelled `LidarPropIntenstiy` in the code.
Fixed the typo.