### PR TITLE
feat: Add search path for Jetson Orin high-speed serial port

### DIFF
--- a/core/serial/impl/unix/list_ports_linux.cpp
+++ b/core/serial/impl/unix/list_ports_linux.cpp
@@ -294,6 +294,7 @@ serial::list_ports()
   search_globs.push_back("/dev/ttyUSB*");
   search_globs.push_back("/dev/tty.*");
   search_globs.push_back("/dev/cu.*");
+  search_globs.push_back("/dev/ttyTHS*");
 
   vector<string> devices_found = glob(search_globs);
 


### PR DESCRIPTION
Proposal
This change adds the Jetson Orin's UART port to the search list.

Reason for Change
The UART port on Jetson devices is exposed under a different path (/dev/ttyTHS*) than typical serial devices. The current program does not search for this path and therefore fails to recognize the port.

Change Description
This commit adds /dev/ttyTHS* to the serial port search list.

Effect of Change
This allows Jetson Orin users to utilize the program without needing to modify the code.