### PR TITLE
fix: Prevent serial port overwrite issue

### DIFF
--- a/src/YDlidarDriver.cpp
+++ b/src/YDlidarDriver.cpp
@@ -2578,9 +2578,14 @@ namespace ydlidar
 
     for (std::vector<PortInfo>::iterator it = lst.begin(); it != lst.end(); it++)
     {
-      std::string port = "ydlidar" + (*it).device_id;
-      ports[port] = (*it).port;
-    }
+      std::string port;
+      if ((*it).device_id.empty()) {
+          port = "ydlidar" + (*it).port;
+        } else {
+          port = "ydlidar" + (*it).device_id;
+        }
+        ports[port] = (*it).port;
+     }
 
     return ports;
   }


### PR DESCRIPTION
Proposal
This change fixes an issue where devices without a unique device_id were being overwritten in the port list, leaving only the last-found device's port.

Reason for Change
The current port search logic treats devices with an empty device_id (e.g., /dev/ttyTHS*) as having the same key. As a result, when multiple such devices were present, the information for all but the last one was lost in the list.

Change Description
The logic has been revised to use the port name itself as the map key when the device_id is empty. This ensures each port is uniquely identified, preventing data from being overwritten.

Effect of Change
With this fix, multiple ports like ttyTHS* will all be correctly displayed in the port list, allowing users to select the appropriate port.