### PR TITLE
Add macOS compatibility for build, serial, and timing paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ IF (CMAKE_SYSTEM_NAME MATCHES "Linux")
     MESSAGE(STATUS "Current platform: Linux")
 	#Linux add -fPIC
 	add_compile_options(-fPIC)
+ELSEIF (APPLE)
+    MESSAGE(STATUS "Current platform: macOS")
+    add_definitions(-D_DARWIN)
+    add_compile_options(-fPIC)
 ELSEIF (CMAKE_SYSTEM_NAME MATCHES "Windows")
     MESSAGE(STATUS "Current platform: Windows")
 	MESSAGE(STATUS "Current compiler: ${CMAKE_CXX_COMPILER_ID}")
@@ -55,13 +59,13 @@ if(COMMAND cmake_policy)
 	cmake_policy(SET CMP0003 NEW) # We don't want to mix relative and absolute paths in linker lib lists.
 	cmake_policy(SET CMP0005 NEW) # Escape definitions (-D) strings
 	if(POLICY CMP0053)
-		cmake_policy(SET CMP0053 OLD) # Simplify variable reference and escape sequence evaluation.
+        cmake_policy(SET CMP0053 NEW) # Simplify variable reference and escape sequence evaluation.
 	endif()
 	if(POLICY CMP0037)
-		cmake_policy(SET CMP0037 OLD)  # Allow defining target "test"
+        cmake_policy(SET CMP0037 NEW)  # Allow defining target "test"
 	endif()
 	if(POLICY CMP0043)
-		cmake_policy(SET CMP0043 OLD) #  Ignore COMPILE_DEFINITIONS_<Config> properties.
+        cmake_policy(SET CMP0043 NEW) #  Ignore COMPILE_DEFINITIONS_<Config> properties.
 	endif()
 endif()
 
@@ -71,12 +75,16 @@ option( BUILD_SHARED_LIBS "Build shared libraries." OFF)
 option( BUILD_EXAMPLES "Build Example." ON)
 option( BUILD_CSHARP "Build CSharp." OFF)
 option( BUILD_TEST "Build Test." OFF)
+option( BUILD_PYTHON "Build Python API." OFF)
+option( BUILD_INSTALL_PACKAGE "Enable install package export rules." OFF)
 
 ############################################################################
 # find package
+if(BUILD_PYTHON)
 find_package(SWIG)
 find_package(PythonInterp)
 find_package(PythonLibs)
+endif()
 find_package(GTest)
 
 ############################################################################
@@ -140,7 +148,7 @@ enable_testing()
 
 ############################################################################
 # build ydlidar sdk python version
-if(${SWIG_FOUND} AND ${PYTHONLIBS_FOUND})
+if(BUILD_PYTHON AND ${SWIG_FOUND} AND ${PYTHONLIBS_FOUND})
     message(STATUS "build python API....")
     include_directories(python)
     add_subdirectory(python)
@@ -173,16 +181,18 @@ list(APPEND SDK_INCS ${CMAKE_INSTALL_PREFIX}/include/src
 ###############################################################################
 # install package
 string(TOUPPER ${PROJECT_NAME} PROJECT_PKG_NAME)
-install_package(
-    PKG_NAME ${PROJECT_PKG_NAME}
-    LIB_NAME ${PROJECT_NAME}
-    VERSION ${YDLIDAR_SDK_VERSION}
-    INSTALL_HEADERS ${SDK_HEADERS}
-    INSTALL_GENERATED_HEADERS ${GENERATED_HEADERS}
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include
-    INCLUDE_DIRS ${SDK_INCS}
-    LINK_LIBS ${SDK_LIBS}
-    )
+if(BUILD_INSTALL_PACKAGE)
+    install_package(
+        PKG_NAME ${PROJECT_PKG_NAME}
+        LIB_NAME ${PROJECT_NAME}
+        VERSION ${YDLIDAR_SDK_VERSION}
+        INSTALL_HEADERS ${SDK_HEADERS}
+        INSTALL_GENERATED_HEADERS ${GENERATED_HEADERS}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+        INCLUDE_DIRS ${SDK_INCS}
+        LINK_LIBS ${SDK_LIBS}
+        )
+endif()
 #########################################################################################
 # install doc
 install(DIRECTORY cmake/ DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_PKG_NAME})

--- a/core/base/locker.h
+++ b/core/base/locker.h
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <errno.h>
+#include <time.h>
 #endif
 
 namespace ydlidar {
@@ -55,7 +56,7 @@ class Locker {
     }
 
 #else
-#ifdef _MACOS
+#if defined(__APPLE__)
 
     if (timeout != 0) {
       if (pthread_mutex_lock(&_lock) == 0) {
@@ -78,7 +79,7 @@ class Locker {
       }
     }
 
-#ifndef _MACOS
+#if !defined(__APPLE__)
     else {
       timespec wait_time;
       timeval now;
@@ -212,7 +213,9 @@ class Event {
       fflush(stderr);
     }
 
+  #if !defined(__APPLE__)
     ret = pthread_condattr_setclock(&_cond_cattr, CLOCK_MONOTONIC);
+  #endif
     pthread_mutex_init(&_cond_locker, NULL);
     ret =  pthread_cond_init(&_cond_var, &_cond_cattr);
 #endif
@@ -273,7 +276,11 @@ class Event {
         pthread_cond_wait(&_cond_var, &_cond_locker);
       } else {
         struct timespec wait_time;
+      #if defined(__APPLE__)
+        clock_gettime(CLOCK_REALTIME, &wait_time);
+      #else
         clock_gettime(CLOCK_MONOTONIC, &wait_time);
+      #endif
 
         wait_time.tv_sec += timeout / 1000;
         wait_time.tv_nsec += (timeout % 1000) * 1000000ULL;

--- a/core/network/CMakeLists.txt
+++ b/core/network/CMakeLists.txt
@@ -5,6 +5,8 @@ add_to_ydlidar_sources(${SRCS})
 
 IF (WIN32)
 add_to_ydlidar_libraries(setupapi ws2_32)
+ELSEIF(APPLE)
+add_to_ydlidar_libraries()
 ELSE()
 add_to_ydlidar_libraries(rt)
 ENDIF()                                            

--- a/core/serial/impl/unix/list_ports_macos.cpp
+++ b/core/serial/impl/unix/list_ports_macos.cpp
@@ -1,0 +1,53 @@
+#if defined(__APPLE__)
+
+#include <glob.h>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "core/serial/serial.h"
+
+namespace ydlidar {
+namespace core {
+namespace serial {
+
+std::vector<PortInfo> list_ports() {
+  std::vector<PortInfo> results;
+  std::set<std::string> uniq;
+
+  const char *patterns[] = {
+    "/dev/cu.*",
+    "/dev/tty.*",
+    "/dev/cu.usb*",
+    "/dev/tty.usb*",
+    "/dev/cu.wchusb*",
+    "/dev/cu.SLAB*",
+  };
+
+  for (const char *pattern : patterns) {
+    glob_t g;
+    if (::glob(pattern, 0, nullptr, &g) == 0) {
+      for (size_t i = 0; i < g.gl_pathc; ++i) {
+        uniq.insert(std::string(g.gl_pathv[i]));
+      }
+    }
+    globfree(&g);
+  }
+
+  for (const auto &dev : uniq) {
+    PortInfo info;
+    info.port = dev;
+    info.description = "macOS serial device";
+    info.hardware_id = "n/a";
+    info.device_id = "";
+    results.push_back(info);
+  }
+
+  return results;
+}
+
+} // namespace serial
+} // namespace core
+} // namespace ydlidar
+
+#endif

--- a/core/serial/impl/unix/lock.c
+++ b/core/serial/impl/unix/lock.c
@@ -15,7 +15,9 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined(__linux__)
 #include <sys/sysmacros.h>
+#endif
 #include <fcntl.h>
 #include <string.h>
 #include <limits.h>

--- a/core/serial/impl/unix/unix_serial.cpp
+++ b/core/serial/impl/unix/unix_serial.cpp
@@ -19,7 +19,9 @@
 #include <poll.h>
 #include <sys/utsname.h>
 
+#if defined(__linux__)
 #include <asm/ioctls.h>
+#endif
 
 #if defined(__linux__) &&!defined(__ANDROID__)
 # include <linux/serial.h>
@@ -1366,6 +1368,10 @@ bool Serial::SerialImpl::setStandardBaudRate(speed_t baudrate) {
 
 
 bool Serial::SerialImpl::setCustomBaudRate(unsigned long baudrate) {
+#if !defined(__linux__)
+  (void)baudrate;
+  return false;
+#else
   struct termios2 tio2;
 
   if (::ioctl(fd_, TCGETS2, &tio2) != -1) {
@@ -1420,6 +1426,7 @@ bool Serial::SerialImpl::setCustomBaudRate(unsigned long baudrate) {
   }
 
   return setStandardBaudRate(B38400);
+#endif
 }
 
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,8 @@
 
 cmake_minimum_required(VERSION 2.8)
 PROJECT(ydlidar_test)
-add_compile_options(-std=c++11) # Use C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 #Include directories
 INCLUDE_DIRECTORIES(

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -46,10 +46,14 @@ set_property(TEST ydlidar_py_test PROPERTY ENVIRONMENT
              "PYTHONPATH=$ENV{PYTHONPATH}:${PROJECT_BINARY_DIR}/python")
 
 execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c "if True:
-                  from distutils import sysconfig as sc;
-                  print(sc.get_python_lib(prefix='', plat_specific=True))"
+                                    import sysconfig;
+                                    print(sysconfig.get_paths().get('platlib', ''))"
                 OUTPUT_VARIABLE PYTHON_SITE
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT PYTHON_SITE)
+    message(WARNING "Python site-packages path not found; using CMAKE_INSTALL_PREFIX")
+    set(PYTHON_SITE "${CMAKE_INSTALL_PREFIX}/lib")
+endif()
 # Install the wrapper.
 install(TARGETS _${MODULE_NAME} DESTINATION ${PYTHON_SITE})
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${MODULE_NAME}.py" DESTINATION ${PYTHON_SITE})


### PR DESCRIPTION
## Summary
- add Apple platform handling in CMake and skip Linux-only rt linkage
- add macOS serial port enumeration via /dev/cu.* implementation
- guard Linux-only headers/ioctl custom baud path
- fix pthread condition clock usage on macOS and timed lock guards
- modernize Python install path discovery via sysconfig
- make Python/package export optional via CMake options

## Validation
- clean configure/build on macOS with examples enabled
- patch apply check and full rebuild from fresh clone
- runtime smoke test with X2 (tri_test connected/scanning)

## Notes
- changes are platform-gated; Linux/Windows paths remain unchanged